### PR TITLE
fixed #138  adding gssoc-ext and hacktober fest logos to the readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 **My Calendar App** is a full-stack application designed to help users manage their schedules, expenses, to-dos, and notes all in one place. The app provides a seamless and intuitive user interface for efficient day-to-day management, along with robust backend support for secure data handling and user authentication.
 
+## This Project is officially accepted for 
+<br> 
+<div style="display: flex; justify-content: center; align-items: center;">
+  <img src="https://raw.githubusercontent.com/SwanandD121/FeatherPerfect_fe/refs/heads/main/Untitled%20design.png" alt="GSSoC 2024 Extd" style="max-width: 50%;">
+  <img src="https://pbs.twimg.com/profile_images/1831003149072535554/leInyk8A_400x400.jpg" alt="Hacktoberfest 2024" style="max-width: 20%; margin-left: 20px;">
+</div>
+<br>
+
 ## ✨ Features
 
 - 🔐 **User Authentication**: Secure login and registration using JWT (JSON Web Tokens).


### PR DESCRIPTION
### 🛠️ Fixes Issue
Closes #138 

### 👨‍💻 Description
adding gssoc-ext and hacktober fest logos to the readme 

### 📄 Type of Change

- [x] Documentation update (adds or updates related documentation)

### 📷 Screenshots/GIFs (if any)
![image](https://github.com/user-attachments/assets/f6c4295b-a25f-4e02-8170-7572d19544fd)


### ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have viewed deployment of my code.
- [x] My changes generate no new warnings.
- [x] I have added documentation to explain my changes.

### 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.
